### PR TITLE
Fixed typo and added 'Canonical Ltd.'

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -6207,7 +6207,7 @@
         {
             "domains": ["canonical.com"],
             "company_name": "Canonical",
-            "aliases": ["Canoncail, Ltd."]
+            "aliases": ["Canonical, Ltd.", "Canonical Ltd."]
         },
         {
             "domains": ["centraldesktop.com"],


### PR DESCRIPTION
Fixed spelling for 'Canonical, Ltd.' and also added 'Canonical Ltd.'
